### PR TITLE
Make it easier to run tests locally

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,4 @@
+PSQL_DSN=postgresql+asyncpg://postgres:dev@localhost/postgres
+DEBUG=True
+JWT_PRIVATE_KEY='/path/to/jwt_rsa_key'
+JWT_PUBLIC_KEY='/path/to/jwt_rsa_key.pub'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.10.1"
+        python-version: "3.10.4"
     - name: Install dependencies
       run: |
         make dev-install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,8 @@ jobs:
     name: Continuous integration
     runs-on: ubuntu-latest
     env:
-      JWT_PUBLIC_KEY_CONTENTS: ${{ secrets.JWT_PUBLIC_KEY }}
-      JWT_PRIVATE_KEY_CONTENTS: ${{ secrets.JWT_PRIVATE_KEY }}
-      JWT_PUBLIC_KEY: ./jwt_key.pub
-      JWT_PRIVATE_KEY: ./jwt_key
+      JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
+      JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
       PSQL_DSN: postgresql+asyncpg://postgres:aioauth_fastapi_demo@localhost:5432/aioauth_fastapi_demo
     services:
       postgres:
@@ -42,11 +40,6 @@ jobs:
     - name: Run lint
       run: |
         make lint
-    - name: Copy JWT keys to files
-      shell: bash
-      run: |
-        echo "$JWT_PUBLIC_KEY_CONTENTS" > ./jwt_key.pub
-        echo "$JWT_PRIVATE_KEY_CONTENTS" > ./jwt_key
     - name: Run tests
       run: |
         make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,10 @@ jobs:
     name: Continuous integration
     runs-on: ubuntu-latest
     env:
-      JWT_PUBLIC_KEY: ${{ secrets.JWT_PUBLIC_KEY }}
-      JWT_PRIVATE_KEY: ${{ secrets.JWT_PRIVATE_KEY }}
+      JWT_PUBLIC_KEY_CONTENTS: ${{ secrets.JWT_PUBLIC_KEY }}
+      JWT_PRIVATE_KEY_CONTENTS: ${{ secrets.JWT_PRIVATE_KEY }}
+      JWT_PUBLIC_KEY: ./jwt_key.pub
+      JWT_PRIVATE_KEY: ./jwt_key
       PSQL_DSN: postgresql+asyncpg://postgres:aioauth_fastapi_demo@localhost:5432/aioauth_fastapi_demo
     services:
       postgres:
@@ -40,6 +42,11 @@ jobs:
     - name: Run lint
       run: |
         make lint
+    - name: Copy JWT keys to files
+      shell: bash
+      run: |
+        echo "$JWT_PUBLIC_KEY_CONTENTS" > ./jwt_key.pub
+        echo "$JWT_PRIVATE_KEY_CONTENTS" > ./jwt_key
     - name: Run tests
       run: |
         make test

--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ celerybeat-schedule
 
 # Environments
 .env
-.env*
 .venv
 env/
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ fail_fast: true
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.6b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/aioauth_fastapi/forms.py
+++ b/aioauth_fastapi/forms.py
@@ -35,4 +35,4 @@ class TokenForm:
 @dataclass
 class TokenIntrospectForm:
     token: Optional[str] = Form(None)
-    token_type: Optional[TokenType] = Form(None)
+    token_type_hint: Optional[TokenType] = Form(None)

--- a/aioauth_fastapi/router.py
+++ b/aioauth_fastapi/router.py
@@ -56,11 +56,11 @@ def get_oauth2_router(
     """Function will create FastAPI router with the following oauth2 endpoints:
 
         * POST /token
-            * Endpoint creates token response by :py:meth:`aioauth.server.AuthorizationServer.create_token_response`
+            * Endpoint creates a token response by :py:meth:`aioauth.server.AuthorizationServer.create_token_response`
         * POST `/token/introspect`
-            * Endpoint creates token introspection by :py:meth:`aioauth.server.AuthorizationServer.create_token_introspection_response`
+            * Endpoint creates a token introspection by :py:meth:`aioauth.server.AuthorizationServer.create_token_introspection_response`
         * GET `/authorize`
-            * Endpoint creates authorization response by :py:meth:`aioauth.server.AuthorizationServer.create_authorization_response`
+            * Endpoint creates an authorization response by :py:meth:`aioauth.server.AuthorizationServer.create_authorization_response`
 
     Returns:
         :py:class:`fastapi.APIRouter`.

--- a/aioauth_fastapi_demo/README.md
+++ b/aioauth_fastapi_demo/README.md
@@ -30,13 +30,10 @@ Apply migrations
 alembic upgrade head
 ```
 
-Create .env file:
+Create .env file (and adjust to your local setup):
 
 ```
-PSQL_DSN=postgresql+asyncpg://user@localhost/database
-DEBUG=True
-JWT_PRIVATE_KEY=''
-JWT_PUBLIC_KEY=''
+cp .env.dist .env
 ```
 
 Run local server

--- a/aioauth_fastapi_demo/README.md
+++ b/aioauth_fastapi_demo/README.md
@@ -4,7 +4,7 @@ Demo server was deployed to heroku: [https://aioauth-fastapi.herokuapp.com/api/o
 
 It can be tested on [https://openidconnect.net/](https://openidconnect.net/) and [https://oidcdebugger.com/](https://oidcdebugger.com/) playgrounds.
 
-### Client credentils of demo server
+### Client credentials of demo server
 
 ```
 Authorization Endpoint: https://aioauth-fastapi.herokuapp.com/oauth2/authorize

--- a/aioauth_fastapi_demo/README.md
+++ b/aioauth_fastapi_demo/README.md
@@ -24,16 +24,21 @@ Install requirements:
 pip install -e ."[dev]"
 ```
 
+Run database server
+
+```
+docker compose up
+```
+
+Create .env file (and adjust to your local setup):
+```
+cp .env.dist .env
+```
+
 Apply migrations
 
 ```
 alembic upgrade head
-```
-
-Create .env file (and adjust to your local setup):
-
-```
-cp .env.dist .env
 ```
 
 Run local server

--- a/aioauth_fastapi_demo/README.md
+++ b/aioauth_fastapi_demo/README.md
@@ -33,7 +33,7 @@ alembic upgrade head
 Create .env file:
 
 ```
-PSQL_DSN=SQLAlchemy+asyncpg://user@localhost/database
+PSQL_DSN=postgresql+asyncpg://user@localhost/database
 DEBUG=True
 JWT_PRIVATE_KEY=''
 JWT_PUBLIC_KEY=''

--- a/aioauth_fastapi_demo/oauth2/storage.py
+++ b/aioauth_fastapi_demo/oauth2/storage.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.expression import delete
 
 from ..config import settings
 from ..storage.sqlalchemy import SQLAlchemyStorage
-from ..users.crypto import encode_jwt, get_jwt, read_key_from_env_var_file_path
+from ..users.crypto import encode_jwt, get_jwt, read_rsa_key_from_env
 from ..users.models import User
 from .models import AuthorizationCode as AuthorizationCodeDB
 from .models import Client as ClientDB
@@ -244,6 +244,6 @@ class Storage(BaseStorage):
         return encode_jwt(
             expires_delta=settings.ACCESS_TOKEN_EXP,
             sub=str(request.user.id),
-            secret=read_key_from_env_var_file_path(settings.JWT_PRIVATE_KEY),
+            secret=read_rsa_key_from_env(settings.JWT_PRIVATE_KEY),
             additional_claims=user_data,
         )

--- a/aioauth_fastapi_demo/oauth2/storage.py
+++ b/aioauth_fastapi_demo/oauth2/storage.py
@@ -11,7 +11,7 @@ from sqlalchemy.sql.expression import delete
 
 from ..config import settings
 from ..storage.sqlalchemy import SQLAlchemyStorage
-from ..users.crypto import encode_jwt, get_jwt
+from ..users.crypto import encode_jwt, get_jwt, read_key_from_env_var_file_path
 from ..users.models import User
 from .models import AuthorizationCode as AuthorizationCodeDB
 from .models import Client as ClientDB
@@ -244,6 +244,6 @@ class Storage(BaseStorage):
         return encode_jwt(
             expires_delta=settings.ACCESS_TOKEN_EXP,
             sub=str(request.user.id),
-            secret=settings.JWT_PRIVATE_KEY,
+            secret=read_key_from_env_var_file_path(settings.JWT_PRIVATE_KEY),
             additional_claims=user_data,
         )

--- a/aioauth_fastapi_demo/users/backends.py
+++ b/aioauth_fastapi_demo/users/backends.py
@@ -2,7 +2,7 @@ from fastapi.security.utils import get_authorization_scheme_param
 from starlette.authentication import AuthCredentials, AuthenticationBackend
 
 from ..config import settings
-from .crypto import authenticate, read_key_from_env_var_file_path
+from .crypto import authenticate, read_rsa_key_from_env
 from .models import User, UserAnonymous
 
 
@@ -16,7 +16,7 @@ class TokenAuthenticationBackend(AuthenticationBackend):
         if not token:
             return AuthCredentials(), UserAnonymous()
 
-        key = read_key_from_env_var_file_path(settings.JWT_PUBLIC_KEY)
+        key = read_rsa_key_from_env(settings.JWT_PUBLIC_KEY)
 
         is_authenticated, decoded_token = authenticate(token=token, key=key)
 

--- a/aioauth_fastapi_demo/users/backends.py
+++ b/aioauth_fastapi_demo/users/backends.py
@@ -1,9 +1,8 @@
 from fastapi.security.utils import get_authorization_scheme_param
 from starlette.authentication import AuthCredentials, AuthenticationBackend
 
-from aioauth_fastapi_demo.users.crypto import authenticate
-
 from ..config import settings
+from .crypto import authenticate, read_key_from_env_var_file_path
 from .models import User, UserAnonymous
 
 
@@ -17,7 +16,7 @@ class TokenAuthenticationBackend(AuthenticationBackend):
         if not token:
             return AuthCredentials(), UserAnonymous()
 
-        key = settings.JWT_PUBLIC_KEY
+        key = read_key_from_env_var_file_path(settings.JWT_PUBLIC_KEY)
 
         is_authenticated, decoded_token = authenticate(token=token, key=key)
 

--- a/aioauth_fastapi_demo/users/crypto.py
+++ b/aioauth_fastapi_demo/users/crypto.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import math
 import pathlib
+import re
 import secrets
 import string
 import uuid
@@ -71,13 +72,37 @@ def make_random_password() -> str:
     return "".join(secrets.choice(alphabet) for _ in range(16))
 
 
+def reformat_rsa_key(rsa_key: str) -> str:
+    """Reformat an RSA PEM key without newlines to one with correct newline characters
+
+    @param rsa_key: the PEM RSA key lacking newline characters
+    @return: the reformatted PEM RSA key with appropriate newline characters
+    """
+    # split headers from the body
+    split_rsa_key = re.split(r"(-+)", rsa_key)
+
+    # add newlines between headers and body
+    split_rsa_key.insert(4, "\n")
+    split_rsa_key.insert(6, "\n")
+
+    reformatted_rsa_key = "".join(split_rsa_key)
+
+    # reformat body
+    return RSA.importKey(reformatted_rsa_key).exportKey().decode("utf-8")
+
+
 def read_rsa_key_from_env(file_path: str) -> str:
     path = pathlib.Path(file_path)
 
+    # path to rsa key file
     if path.is_file():
         with open(file_path, "rb") as key_file:
             jwt_private_key = RSA.importKey(key_file.read()).exportKey()
         return jwt_private_key.decode("utf-8")
+
+    # rsa key without newlines
+    if "\n" not in file_path:
+        return reformat_rsa_key(file_path)
 
     return file_path
 

--- a/aioauth_fastapi_demo/users/crypto.py
+++ b/aioauth_fastapi_demo/users/crypto.py
@@ -70,6 +70,12 @@ def make_random_password() -> str:
     return "".join(secrets.choice(alphabet) for _ in range(16))
 
 
+def read_key_from_env_var_file_path(file_path: str) -> str:
+    with open(file_path, "rb") as key_file:
+        jwt_private_key = RSA.importKey(key_file.read()).exportKey()
+    return jwt_private_key.decode("utf-8")
+
+
 def encode_jwt(
     expires_delta,
     sub,
@@ -110,7 +116,7 @@ def decode_jwt(
 def get_jwt(user):
     access_token = encode_jwt(
         sub=str(user.id),
-        secret=settings.JWT_PRIVATE_KEY,
+        secret=read_key_from_env_var_file_path(settings.JWT_PRIVATE_KEY),
         expires_delta=settings.ACCESS_TOKEN_EXP,
         additional_claims={
             "token_type": "access",
@@ -123,7 +129,7 @@ def get_jwt(user):
 
     refresh_token = encode_jwt(
         sub=str(user.id),
-        secret=settings.JWT_PRIVATE_KEY,
+        secret=read_key_from_env_var_file_path(settings.JWT_PRIVATE_KEY),
         expires_delta=settings.REFRESH_TOKEN_EXP,
         additional_claims={
             "token_type": "refresh",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres
+    restart: always
+    container_name: aioauth_postgres
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=dev
+volumes:
+  pgdata: {}

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ search = "{current_version}"
 replace = "{new_version}"
 
 [tool:pytest]
-addopts = -s --strict -vv --cache-clear --maxfail=1 --cov=aioauth_fastapi_demo --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
+addopts = -s --strict-markers -vv --cache-clear --maxfail=1 --cov=aioauth_fastapi_demo --cov-report=term --cov-report=html --cov-branch --no-cov-on-fail
 
 [coverage:run]
 branch = True

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -2,7 +2,7 @@ from http import HTTPStatus
 from urllib import parse
 
 import pytest
-from aioauth.types import GrantType, ResponseType
+from aioauth.types import GrantType, ResponseType, TokenType
 from async_asgi_testclient import TestClient
 
 from aioauth_fastapi_demo.oauth2.models import Client
@@ -96,3 +96,27 @@ async def test_implicit_flow(http_client: TestClient, user: "User", client: "Cli
     )
 
     assert response.headers.get("location")
+
+
+@pytest.mark.asyncio
+async def test_token_introspection(
+    http_client: TestClient, user: "User", client: "Client"
+):
+    access_token, _ = get_jwt(user)
+
+    with pytest.raises(TypeError):
+        introspect_response = await http_client.post(
+            "/oauth2/token/introspect",
+            form={"token": access_token, "token_type": TokenType.ACCESS.value},
+            # empty basic auth header to ensure get client passes
+            headers={"Authorization": "Basic Og=="},
+        )
+
+    # correct case
+    introspect_response = await http_client.post(
+        "/oauth2/token/introspect",
+        form={"token": access_token, "token_type_hint": TokenType.ACCESS.value},
+        headers={"Authorization": "Basic Og=="},
+    )
+
+    assert introspect_response.status_code == HTTPStatus.OK

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -77,7 +77,7 @@ async def test_authorization_code_flow(
     )
     assert (
         response.status_code == HTTPStatus.BAD_REQUEST
-    ), "re-try token revokation with revoked token should be rejected"
+    ), "re-trying to revoke an already revoked token should be rejected"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hi,

Today I wanted to make a small bugfix in aioauth-fastapi and ensure the tests kept working. However, it turned out to be quite a challenge to actually get the current tests running. So I first made a few adjustments to make the development experience a little bit better:

1. I added a `docker-compose.yml` file to make it easy to run the postgres server locally (and updated the README.md in demo on how to use it)
2. I added a `.env.dist` file that you can use to easily setup a new local `.env` file (and updated the README.md in demo on how to use it)
3.  The pre-commit hooks were throwing some errors because the version of `black` being used was incompatible with click 8.1 and above (see [here](https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click)). I upgraded `black` to the latest version (22.3.0) to resolve the issue.
4. It turned out to be quite challenging to make the RSA keys required by python-jose available as the values of environment variables. Instead, I now use the pydantic Settings object to read the paths to these key files instead, and pass them on to a new function that reads the contents of these key files into strings, in a way that is compatible with `python-jose`. This should also make it easier to run the application on a container platform like Kubernetes.

I have also added the bugfix here:

1. As the new test for token introspection shows: the `/oauth2/token/introspect` endpoint fails when you send a form field named 'token_type' to it. That is because the `Post` class in `aioauth` only has a field named `token_type_hint`. Renaming the field to `token_type_hint` does solve the issue, as the correct case in the test shows.
2. I've also made this field name change in the `TokenIntrospectionForm` class.

I hope these changes can be reviewed and merged @aliev.

Kind regards,

Ben