### PR TITLE
Fix error related to trying to get RequestMethod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.10.4"
+        python-version: "3.10.10"
     - name: Install dependencies
       run: |
         make dev-install

--- a/aioauth_fastapi/utils.py
+++ b/aioauth_fastapi/utils.py
@@ -31,6 +31,9 @@ async def to_oauth2_request(
     headers = HTTPHeaderDict(**request.headers)
     url = str(request.url)
 
+    assert method == "GET" or method == "POST"
+    _method: RequestMethod = method
+
     user = None
 
     if request.user.is_authenticated:
@@ -38,7 +41,7 @@ async def to_oauth2_request(
 
     return OAuth2Request(
         settings=settings,
-        method=RequestMethod[method],
+        method=_method,
         headers=headers,
         post=Post(**post),
         query=Query(**query_params),


### PR DESCRIPTION
I haven't really used `Literal` very much, but regardless, it doesn't seem like some syntax currently used by this library is legal. Here's the error I'm hitting and proposing a solution for:
```
  File ".../venv/lib/python3.10/site-packages/aioauth_fastapi/utils.py", line 41, in to_oauth2_request
    method=RequestMethod[method],
  File "/usr/lib/python3.10/typing.py", line 312, in inner
    return func(*args, **kwds)
  File "/usr/lib/python3.10/typing.py", line 1058, in __getitem__
    _check_generic(self, params, len(self.__parameters__))
  File ".../venv/lib/python3.10/site-packages/typing_extensions.py", line 97, in _check_generic
    raise TypeError(f"{cls} is not a generic class")
TypeError: typing.Literal['GET', 'POST'] is not a generic class
```

I'm open to alternatives if y'all have better ideas.