### PR TITLE
Better handle subclasses of aioauth.requests.TRequest

### DIFF
--- a/aioauth_fastapi/router.py
+++ b/aioauth_fastapi/router.py
@@ -41,17 +41,30 @@ Usage example
 ----
 """
 
+from typing import Callable, TypeVar
+
 from aioauth.config import Settings
-from aioauth.requests import Query
+from aioauth.requests import Query, TRequest
 from aioauth.server import AuthorizationServer
+from aioauth.storage import TStorage
 from fastapi import APIRouter, Depends, Request
 
 from .forms import TokenForm, TokenIntrospectForm
-from .utils import to_fastapi_response, to_oauth2_request
+from .utils import (
+    RequestArguments,
+    default_request_factory,
+    to_fastapi_response,
+    to_oauth2_request,
+)
+
+
+ARequest = TypeVar("ARequest", bound=TRequest)
 
 
 def get_oauth2_router(
-    authorization_server: AuthorizationServer, settings: Settings = Settings()
+    authorization_server: AuthorizationServer[ARequest, TStorage],
+    settings: Settings = Settings(),
+    request_factory: Callable[[RequestArguments], ARequest] = default_request_factory,
 ) -> APIRouter:
     """Function will create FastAPI router with the following oauth2 endpoints:
 
@@ -69,7 +82,9 @@ def get_oauth2_router(
 
     @router.post("/token")
     async def token(request: Request, form: TokenForm = Depends()):
-        oauth2_request = await to_oauth2_request(request, settings)
+        oauth2_request = await to_oauth2_request(
+            request=request, request_factory=request_factory, settings=settings
+        )
         oauth2_response = await authorization_server.create_token_response(
             oauth2_request
         )
@@ -77,7 +92,9 @@ def get_oauth2_router(
 
     @router.post("/token/introspect")
     async def token_introspect(request: Request, form: TokenIntrospectForm = Depends()):
-        oauth2_request = await to_oauth2_request(request, settings)
+        oauth2_request = await to_oauth2_request(
+            request=request, request_factory=request_factory, settings=settings
+        )
         oauth2_response = (
             await authorization_server.create_token_introspection_response(
                 oauth2_request
@@ -87,7 +104,9 @@ def get_oauth2_router(
 
     @router.get("/authorize")
     async def authorize(request: Request, query: Query = Depends()):
-        oauth2_request = await to_oauth2_request(request, settings)
+        oauth2_request = await to_oauth2_request(
+            request=request, request_factory=request_factory, settings=settings
+        )
         oauth2_response = await authorization_server.create_authorization_response(
             oauth2_request
         )

--- a/aioauth_fastapi/router.py
+++ b/aioauth_fastapi/router.py
@@ -44,12 +44,11 @@ Usage example
 from typing import Callable, TypeVar
 
 from aioauth.config import Settings
-from aioauth.requests import Query, TRequest
+from aioauth.requests import TRequest
 from aioauth.server import AuthorizationServer
 from aioauth.storage import TStorage
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Request
 
-from .forms import TokenForm, TokenIntrospectForm
 from .utils import (
     RequestArguments,
     default_request_factory,
@@ -81,7 +80,7 @@ def get_oauth2_router(
     router = APIRouter()
 
     @router.post("/token")
-    async def token(request: Request, form: TokenForm = Depends()):
+    async def token(request: Request):
         oauth2_request = await to_oauth2_request(
             request=request, request_factory=request_factory, settings=settings
         )
@@ -91,7 +90,7 @@ def get_oauth2_router(
         return await to_fastapi_response(oauth2_response)
 
     @router.post("/token/introspect")
-    async def token_introspect(request: Request, form: TokenIntrospectForm = Depends()):
+    async def token_introspect(request: Request):
         oauth2_request = await to_oauth2_request(
             request=request, request_factory=request_factory, settings=settings
         )
@@ -103,7 +102,7 @@ def get_oauth2_router(
         return await to_fastapi_response(oauth2_response)
 
     @router.get("/authorize")
-    async def authorize(request: Request, query: Query = Depends()):
+    async def authorize(request: Request):
         oauth2_request = await to_oauth2_request(
             request=request, request_factory=request_factory, settings=settings
         )

--- a/aioauth_fastapi/utils.py
+++ b/aioauth_fastapi/utils.py
@@ -9,23 +9,50 @@ Core utils for integration with FastAPI
 """
 
 import json
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
 
 from aioauth.collections import HTTPHeaderDict
 from aioauth.config import Settings
-from aioauth.requests import Post, Query
+from aioauth.requests import Post, Query, TRequest, TUser
 from aioauth.requests import Request as OAuth2Request
 from aioauth.responses import Response as OAuth2Response
 from fastapi import Request, Response
 
 
+@dataclass
+class RequestArguments:
+    headers: HTTPHeaderDict
+    method: str
+    post_args: Dict
+    query_args: Dict
+    settings: Settings
+    url: str
+    user: Optional[TUser]
+
+
+def default_request_factory(request_args: RequestArguments) -> OAuth2Request:
+    return OAuth2Request(
+        headers=request_args.headers,
+        method=request_args.method,  # type: ignore
+        post=Post(**request_args.post_args),  # type: ignore
+        query=Query(**request_args.query_args),  # type: ignore
+        settings=request_args.settings,
+        url=request_args.url,
+        user=request_args.user,
+    )
+
+
 async def to_oauth2_request(
-    request: Request, settings: Settings = Settings()
-) -> OAuth2Request:
+    request: Request,
+    settings: Settings = Settings(),
+    request_factory: Callable[[RequestArguments], TRequest] = default_request_factory,
+) -> TRequest:
     """Converts :py:class:`fastapi.Request` instance to :py:class:`aioauth.requests.Request` instance"""
     form = await request.form()
 
-    post = dict(form)
-    query_params = dict(request.query_params)
+    post_args = dict(form)
+    query_args = dict(request.query_params)
     method = request.method
     headers = HTTPHeaderDict(**request.headers)
     url = str(request.url)
@@ -35,15 +62,16 @@ async def to_oauth2_request(
     if request.user.is_authenticated:
         user = request.user
 
-    return OAuth2Request(
-        settings=settings,
-        method=method,  # type: ignore
+    request_args = RequestArguments(
         headers=headers,
-        post=Post(**post),  # type: ignore
-        query=Query(**query_params),  # type: ignore
+        method=method,
+        post_args=post_args,
+        query_args=query_args,
+        settings=settings,
         url=url,
         user=user,
     )
+    return request_factory(request_args)
 
 
 async def to_fastapi_response(oauth2_response: OAuth2Response) -> Response:

--- a/aioauth_fastapi_demo/oauth2/endpoints.py
+++ b/aioauth_fastapi_demo/oauth2/endpoints.py
@@ -1,5 +1,5 @@
 from aioauth.config import Settings
-from aioauth.requests import Query
+from aioauth.requests import Query, Request as OAuth2Request
 from aioauth.server import AuthorizationServer
 from fastapi import APIRouter, Depends, Request
 
@@ -27,7 +27,7 @@ async def token(
 ):
     oauth2_storage = Storage(storage=storage)
     authorization_server = AuthorizationServer(storage=oauth2_storage)
-    oauth2_request = await to_oauth2_request(request, settings)
+    oauth2_request: OAuth2Request = await to_oauth2_request(request, settings)
     oauth2_response = await authorization_server.create_token_response(oauth2_request)
     return await to_fastapi_response(oauth2_response)
 
@@ -40,7 +40,7 @@ async def token_introspect(
 ):
     oauth2_storage = Storage(storage=storage)
     authorization_server = AuthorizationServer(storage=oauth2_storage)
-    oauth2_request = await to_oauth2_request(request, settings)
+    oauth2_request: OAuth2Request = await to_oauth2_request(request, settings)
     oauth2_response = await authorization_server.create_token_introspection_response(
         oauth2_request
     )
@@ -55,7 +55,7 @@ async def authorize(
 ):
     oauth2_storage = Storage(storage=storage)
     authorization_server = AuthorizationServer(storage=oauth2_storage)
-    oauth2_request = await to_oauth2_request(request, settings)
+    oauth2_request: OAuth2Request = await to_oauth2_request(request, settings)
     oauth2_response = await authorization_server.create_authorization_response(
         oauth2_request
     )


### PR DESCRIPTION
This is an attempt to make it possible to use the utilities in this library with arbitrary subclasses of `from aioauth.request import TPost, TQuery, TRequest`. This is achieved by a user of the library defining a custom `request_factory` function that takes a standard set of inputs (the proposed `RequestArguments` class) and returns an appropriate instance of whatever subclass of `aioauth.requests.TRequest`. I think this should be backwards compatible with previous versions of this library.

This all traces back to `aioauth` trying to handle support for different standards by handling standard specific behaviors in standard specific subclasses. For the OIDC scenario, this means being able to use a subclass of `aioauth.requests.Query` that allows the `prompt` argument to the authorization endpoint.