### PR TITLE
Validate client secret for confidential clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: "3.10.10"
+        python-version: "3.10.14"
     - name: Install dependencies
       run: |
         make dev-install

--- a/aioauth_fastapi_demo/admin/models.py
+++ b/aioauth_fastapi_demo/admin/models.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 class ClientCreate(BaseModel):
     client_id: str
-    client_secret: str
+    client_secret: Optional[str]
     grant_types: List[GrantType]
     response_types: List[ResponseType]
     redirect_uris: List[str]

--- a/aioauth_fastapi_demo/oauth2/models.py
+++ b/aioauth_fastapi_demo/oauth2/models.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 class Client(BaseTable, table=True):  # type: ignore
     client_id: str
-    client_secret: str
+    client_secret: Optional[str]
     grant_types: List[str] = Field(sa_column=Column(ARRAY(String)))
     response_types: List[str] = Field(sa_column=Column(ARRAY(String)))
     redirect_uris: List[str] = Field(sa_column=Column(ARRAY(String)))

--- a/aioauth_fastapi_demo/oauth2/storage.py
+++ b/aioauth_fastapi_demo/oauth2/storage.py
@@ -216,6 +216,11 @@ class Storage(BaseStorage):
         if not client_record:
             return None
 
+        if client_secret is not None and client_record.client_secret is not None:
+            # validate the client_secret
+            if client_secret != client_record.client_secret:
+                return None
+
         return Client(
             client_id=client_record.client_id,
             client_secret=client_record.client_secret,

--- a/aioauth_fastapi_demo/storage/migrations/versions/21eb480f8485_initial_migrations.py
+++ b/aioauth_fastapi_demo/storage/migrations/versions/21eb480f8485_initial_migrations.py
@@ -1,8 +1,8 @@
 """Initial migrations
 
-Revision ID: 07a7ace268a7
+Revision ID: 21eb480f8485
 Revises:
-Create Date: 2021-10-02 22:50:10.418498
+Create Date: 2024-08-03 21:35:56.307146
 
 """
 import sqlalchemy as sa
@@ -10,7 +10,7 @@ import sqlmodel
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "07a7ace268a7"
+revision = "21eb480f8485"
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -125,7 +125,7 @@ def upgrade():
         sa.Column("redirect_uris", sa.ARRAY(sa.String()), nullable=True),
         sa.Column("id", sqlmodel.sql.sqltypes.GUID(), nullable=False),
         sa.Column("client_id", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("client_secret", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("client_secret", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
         sa.Column("scope", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
         sa.Column("user_id", sqlmodel.sql.sqltypes.GUID(), nullable=False),
         sa.ForeignKeyConstraint(


### PR DESCRIPTION
As discussed in this thread https://github.com/aliev/aioauth/discussions/91, the example app currently doesn't validate client secrets. This adds validation for client secrets as well as some tests to ensure the functionality works. The database schema was also changed to allow null client secrets for public non-confidential clients.

Before adding validation:

```
FAILED tests/test_oauth2.py::test_authorization_code_no_secret - AssertionError: no client secret for a confidential client should be rejected
FAILED tests/test_oauth2.py::test_authorization_code_wrong_secret - AssertionError: wrong client secret for a confidential client should be rejected

Results (28.04s):
       6 passed
       2 failed
         - tests/test_oauth2.py:88 test_authorization_code_no_secret
         - tests/test_oauth2.py:109 test_authorization_code_wrong_secret
```

After adding validation:
```
Results (26.11s):
       8 passed
```