### PR TITLE
Support access token revocation, include nonce in ID token, other type fixes

### DIFF
--- a/aioauth_fastapi_demo/oauth2/storage.py
+++ b/aioauth_fastapi_demo/oauth2/storage.py
@@ -281,7 +281,7 @@ class Storage(BaseStorage):
         response_type: ResponseType,
         redirect_uri: str,
         nonce: Optional[str] = None,
-        **kwargs
+        **kwargs,
     ) -> str:
         scopes = enforce_list(scope)
         user_data = {}


### PR DESCRIPTION
Hi there, this PR includes some fixes that I had to apply in order to get my storage class implementation to pass type checking:

- The `revoke_token` endpoint needs to be updated to support the new parameters added in https://github.com/aliev/aioauth/pull/84, so that access tokens can be revoked in addition to refresh tokens.

- The nonce isn't being included in the ID token JWT claims.

- Some various inconsequential type issues were present, like strings being used instead of the more specific ResponseType and TokenType classes, kwargs not being present, and the nonce parameter not being optional.

There are still some type errors that remain but I don't think they impact the behaviour.

Thanks for your cooperation with all the PRs this last week. As before this is not urgent for me so feel free to review it when you have time. Shawn